### PR TITLE
Added schema generation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+		    <groupId>org.hibernate</groupId>
+		    <artifactId>hibernate-entitymanager</artifactId>
+		    <version>5.2.12.Final</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.hibernate</groupId>
+		    <artifactId>hibernate-core</artifactId>
+		    <version>5.2.12.Final</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/edu/csula/aquila/util/SchemaGeneration.java
+++ b/src/main/java/edu/csula/aquila/util/SchemaGeneration.java
@@ -1,0 +1,55 @@
+package edu.csula.aquila.util;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+
+import javax.persistence.Persistence;
+
+import org.hibernate.engine.jdbc.internal.DDLFormatterImpl;
+import org.hibernate.engine.jdbc.internal.Formatter;
+
+/**
+ * Generates DDL from JPA annotations.
+ */
+public class SchemaGeneration {
+
+    public static void main( String args[] ) throws IOException
+    {
+        // Write the generated schema to a string
+        StringWriter stringWriter = new StringWriter();
+        Map<String, Object> properties = new HashMap<>();
+        properties.put( "javax.persistence.schema-generation.scripts.action",
+            "create" );
+        properties.put(
+            "javax.persistence.schema-generation.scripts.create-target",
+            stringWriter );
+        Persistence.generateSchema( "aquila", properties );
+
+        // If there is a command line argument, consider it the output file name
+        BufferedWriter out = null;
+        if( args.length > 0 )
+            out = new BufferedWriter( new FileWriter( args[0] ) );
+
+        // Use Hibernate's SQL formatter to format each statement
+        Formatter formatter = new DDLFormatterImpl();
+        Scanner scanner = new Scanner( stringWriter.toString() );
+        while( scanner.hasNextLine() )
+        {
+            String line = formatter.format( scanner.nextLine() ) + ";";
+            System.out.println( line );
+            if( out != null )
+            {
+                out.write( line );
+                out.newLine();
+            }
+        }
+        scanner.close();
+        if( out != null ) out.close();
+    }
+
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,16 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+    version="2.1">
+
+<!-- This is only used by SchemaGeneration.java as Spring Boot does not use persistence.xml -->
+    <persistence-unit name="aquila">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <properties>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />
+            <property name="hibernate.connection.driver_class" value="com.mysql.jdbc.Driver" />
+        </properties>
+    </persistence-unit>
+
+</persistence>


### PR DESCRIPTION
I've added a utility class SchemaGeneration that can generate SQL CREATE TABLE statements from the JPA annotations. In Eclipse, right click on SchemaGeneration.java under the aquila.util package and select Run As -> Java Application. You can see the generated SQL statements in the console. You can also save the generated statements to a file by providing a command line argument to the program.

@bboayes7 @sncisneros After you put in the annotations, run SchemaGeneration to a) check if the annotations are correct, and b) see if the resulting relational tables are what you expect.

- Chengyu